### PR TITLE
cmakelint: Run cmakelint through python

### DIFF
--- a/CMakeLinter.cmake
+++ b/CMakeLinter.cmake
@@ -103,7 +103,7 @@ function (_cmake_lint_get_cmakelint_commandline COMMANDLINE_RETURN)
         set (WARN_ONLY_STATE OFF)
     endif ()
 
-    set (COMMANDLINE_OPTIONS "")
+    set (COMMANDLINE_OPTIONS "${CMAKELINT_EXECUTABLE}")
 
     if (COMMANDLINE_FILTER)
         string (REPLACE ";" "," COMMANDLINE_FILTER "${COMMANDLINE_FILTER}")
@@ -124,7 +124,7 @@ function (_cmake_lint_get_cmakelint_commandline COMMANDLINE_RETURN)
          "-DVERBOSE=OFF"
          "-DWARN_ONLY=${WARN_ONLY_STATE}"
          "-DSOURCES_LAST=ON"
-         "-DEXECUTABLE=${CMAKELINT_EXECUTABLE}"
+         "-DEXECUTABLE=${PYTHON_EXECUTABLE}"
          "-DSOURCES=${COMMANDLINE_SOURCES}"
          "-DOPTIONS=${COMMANDLINE_OPTIONS}"
          -P

--- a/FindCMAKELINT.cmake
+++ b/FindCMAKELINT.cmake
@@ -14,6 +14,8 @@
 
 include ("cmake/tooling-find-pkg-util/ToolingFindPackageUtil")
 
+find_package (PythonInterp)
+
 function (cmake_lint_cmake_linter_cmakelint_find)
 
     if (DEFINED CMAKELINT_FOUND)
@@ -47,7 +49,8 @@ function (cmake_lint_cmake_linter_cmakelint_find)
     psq_check_and_report_tool_version (CMakeLint
                                        "latest"
                                        REQUIRED_VARS
-                                       CMAKELINT_EXECUTABLE)
+                                       CMAKELINT_EXECUTABLE
+                                       PYTHON_EXECUTABLE)
 
 
     set (CMAKELINT_FOUND # NOLINT:style/set_var_case


### PR DESCRIPTION
This is required on Windows, since cmakelint isn't frozen there.
